### PR TITLE
fix: 未初始化RegionEntity()的children属性

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,14 @@ Address(
 ## 1.3 自定义地址文件设置
 
 ```kotlin
-// 文件生成方式见下文
+// 加载自定义地址文件
 val geocoding = GeocodingX("region_2021.dat")
+
+// 添加自定义区县"临平区"
+geocoding.addRegionEntry(330113000000, 330100000000, "临平区", RegionType.District, "", true)
+
+// 保存自定义字典文件
+geocoding.save("xxx.dat")
 ```
 
 ## 1.4 自定义地址设置

--- a/src/main/java/org/bitlap/geocoding/GeocodingX.kt
+++ b/src/main/java/org/bitlap/geocoding/GeocodingX.kt
@@ -102,6 +102,8 @@ open class GeocodingX(val ctx: Context) {
         region.name = name
         region.alias = alias
         region.type = type
+        // 暂时在这里初始化下级行政区划列表
+        region.children = arrayListOf()
         // 1. Add to cache (id -> Region)
         ctx.persister.addRegionEntity(region)
         // 2. Build term index


### PR DESCRIPTION
本次修复问题 #182 对于一个空的dat字典文件，GeocodingX.addRegionEntry时，没有初始化RegionEntity()的children属性，导致下级的行政区划未能成功添加。