### PR TITLE
fix CityLevelDistrict triggers mismatched city&province

### DIFF
--- a/src/main/java/org/bitlap/geocoding/core/impl/RegionInterpreterVisitor.kt
+++ b/src/main/java/org/bitlap/geocoding/core/impl/RegionInterpreterVisitor.kt
@@ -384,14 +384,18 @@ open class RegionInterpreterVisitor (
         }
     }
 
-    private fun updateCityAndProvince(distinct: RegionEntity?) {
-        if (distinct == null) return
+    private fun updateCityAndProvince(district: RegionEntity?) {
+        if (district == null) return
         if (!curDivision.hasCity()) {
-            curDivision.city = persister.getRegion(distinct.parentId)?.also { city ->
-                if (!curDivision.hasProvince()) {
-                    curDivision.province = persister.getRegion(city.parentId)
-                }
+            // CityLevelDistrict类型的parent是省级因此直接赋值city
+            if (district.type == CityLevelDistrict) {
+                curDivision.city = district
+            } else {
+                curDivision.city = persister.getRegion(district.parentId)
             }
+        }
+        if (!curDivision.hasProvince() && curDivision.hasCity()) {
+            curDivision.province = persister.getRegion(curDivision.city!!.parentId)
         }
     }
 

--- a/src/test/java/org/bitlap/geocoding/TestNormalizing.kt
+++ b/src/test/java/org/bitlap/geocoding/TestNormalizing.kt
@@ -516,6 +516,22 @@ class TestNormalizing {
                 "绿地城润园"
             )
         )
+        // fix CityLevelDistrict 识别错误
+        assertEquals(
+            Geocoding.normalizing("陈场镇绿地城润园"),
+            Address(
+                420000000000, "湖北省",
+                429004000000, "仙桃市",
+                429004000000, "仙桃市",
+                429004114000, "陈场镇",
+                429004114000, "陈场镇",
+                null, null,
+                null,
+                null,
+                null,
+                "绿地城润园"
+            )
+        )
     }
 
 


### PR DESCRIPTION
解析上极为Cityleveldistrict地址时出现省份是中国，城市是省份等mismatch的情况
🌰：陈场镇绿地城润园
<img width="534" alt="ERROR  Failures" src="https://github.com/user-attachments/assets/fbf8b8eb-77f4-4646-a0d8-4f29419d82d4">

修改：
加判定如为Cityleveldistrict，设置city和district为同值，然后解析省份